### PR TITLE
[INFRA] Do not specify security provider explicitly for java >13 comp…

### DIFF
--- a/gaia-sdk-java/gaia-sdk-graphql/src/main/kotlin/gaia/sdk/client/HMAC.kt
+++ b/gaia-sdk-java/gaia-sdk-graphql/src/main/kotlin/gaia/sdk/client/HMAC.kt
@@ -1,6 +1,5 @@
 package gaia.sdk.client
 
-import com.sun.crypto.provider.SunJCE
 import java.util.*
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
@@ -29,7 +28,7 @@ class HMAC(secret: String) {
 
     private fun initMac(key: String): Mac {
         val secretKeySpec = SecretKeySpec(key.toByteArray(), "HmacSHA512")
-        val mac = Mac.getInstance("HmacSHA512", SunJCE())
+        val mac = Mac.getInstance("HmacSHA512")
         mac.init(secretKeySpec)
         return mac
     }


### PR DESCRIPTION
…atibility

Higher java versions do not expose com.sun.crypto.provider.SunJCE anymore.
Furthermore it is advised not to specify the security provider explicitly: https://docs.oracle.com/javase/9/security/oracleproviders.htm#JSSEC-GUID-F41EE1C9-DD6A-4BAB-8979-EB7654094029

If we still want to specify the provider explicitly, we should pass its name as String:
val mac = Mac.getInstance("HmacSHA512","SunJCE")